### PR TITLE
Add missing version file and update tryouts CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,5 +46,17 @@ jobs:
         bundler: ${{ matrix.bundler }}
         bundler-cache: true
 
-    - name: Run the tryouts (using gem script, dogfood style)
-      run: ruby exe/try -v try/*_try.rb
+    - name: Run tryouts (-V)
+      run: ruby exe/try -V
+
+    - name: Run tryouts (-v)
+      run: ruby exe/try -v
+
+    - name: Run tryouts (-vf)
+      run: ruby exe/try -vf
+
+    - name: Run tryouts (-q)
+      run: ruby exe/try -q
+
+    - name: Run tryouts (-D)
+      run: ruby exe/try -D

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ etc/config
 log
 tmp
 vendor
+node_modules/
+.pnpm/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tryouts v2.3.0 (2024-04-04)
+# Tryouts v2.3.1 (2024-06-18)
 
 **Ruby tests that read like documentation.**
 

--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,4 +1,4 @@
 ---
 :MAJOR: 2
 :MINOR: 3
-:PATCH: 0
+:PATCH: 1

--- a/exe/try
+++ b/exe/try
@@ -22,16 +22,20 @@ Tryouts.quiet = options[:quiet]
 Tryouts.noisy = options[:noisy]
 Tryouts.fails = options[:fails]
 
-# Find tryouts path
-if ARGV.empty?
-  paths = Dir.glob(
+# Find tryouts path with a path glob unless thin
+# script was called with arguments in which case
+# we consume those as a list of paths.
+paths = if ARGV.empty?
+  Dir.glob(
     ['./{try,tryouts/,.}/*_{try,tryouts}.rb'],
-    base: Dir.pwd,
-    sort: true  # deterministic order
-  )
+    base: Dir.pwd
+  ).sort  # deterministic order
 
 else
-  paths = ARGV
+  ARGV
 end
 
+# Running the tryouts returns the number of
+# test failures so here we pass that value
+# through as the exit code for the script.
 exit Tryouts.run_all(*paths)

--- a/tryouts.gemspec
+++ b/tryouts.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"  # replace with actual license
   s.required_ruby_version = Gem::Requirement.new(">= 2.7.8")
 
-  s.files = Dir["{lib,exe}/**/*", "LICENSE.txt", "README.md"]  # Include the exe folder
+  s.files = Dir["{lib,exe}/**/*", "LICENSE.txt", "README.md", "VERSION.yml"]  # Include the exe folder
   s.bindir = 'exe'  # Specify that executables are in the exe folder
   s.executables = Dir.chdir('exe'){ Dir['*'] }.select { |f| File.file?("exe/#{f}") }
 end


### PR DESCRIPTION
This pull request adds the missing "VERSION.yml" file to the gemspec. Caused `try --version` to fail. 

Also updates the tryouts CI to run tryouts with multiple argument permutations. This will catch issues like the missing version file. 