### PR TITLE
[2024-06-24] Fix for StandardError

### DIFF
--- a/lib/tryouts/testcase.rb
+++ b/lib/tryouts/testcase.rb
@@ -50,7 +50,7 @@ class Tryouts
       Tryouts.debug # extra newline
       failed?
 
-    rescue StandardException => e
+    rescue StandardError => e
       Tryouts.debug "[testcaste.run] #{e.message}", e.backtrace.join($/), $/
       $stdout = STDOUT # restore stdout
       # Continue raising the exception


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect exception class from `StandardException` to `StandardError` in `lib/tryouts/testcase.rb`.
- Ensures proper error handling by rescuing the correct exception type.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testcase.rb</strong><dd><code>Fix incorrect exception class in rescue block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/tryouts/testcase.rb

- Replaced `StandardException` with `StandardError` in rescue block



</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/13/files#diff-32c9b8a47cd92534658eacd181a43d63de39ae811610bc267cd2a1d508c83fba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

