### PR TITLE
Fix thread pool queue size for parallel execution

### DIFF
--- a/lib/tryouts/test_runner.rb
+++ b/lib/tryouts/test_runner.rb
@@ -107,7 +107,7 @@ class Tryouts
       executor = Concurrent::ThreadPoolExecutor.new(
         min_threads: 1,
         max_threads: pool_size,
-        max_queue: pool_size * 2, # Reasonable queue size
+        max_queue: @files.length, # Queue size must accommodate all files
         fallback_policy: :abort # Raise exception if pool and queue are exhausted
       )
 


### PR DESCRIPTION
## Summary

This PR fixes a threading issue in the parallel test execution where the thread pool queue size was too small to handle all test files. The original queue size was `pool_size * 2`, which could cause queue exhaustion when running many test files in parallel.

The change updates the queue size from `pool_size * 2` to `@files.length` to ensure the queue can accommodate all files that need processing.

## Technical Details

**Before**: `max_queue: pool_size * 2` 
**After**: `max_queue: @files.length`

This prevents the `fallback_policy: :abort` from triggering when the number of test files exceeds the queue capacity, which would cause the test runner to crash with an exception.

## Test Plan

- [x] Verified the fix resolves queue exhaustion issues
- [x] Confirmed parallel execution works correctly with large file counts
- [x] No breaking changes to existing parallel execution behavior

🤖 Generated with [Claude Code](https://claude.ai/code)