### PR TITLE
Housekeeping updates from closed pr #52

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["3.4", "3.5"]
-        testgroup: [core, expectations, formatters, translators]
+        ruby: ["3.4", "3.5", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +70,7 @@ jobs:
         run: bundle install
 
       - name: Run framework unit tests with coverage
-        run: COVERAGE=1 FORCE_COLOR=1 bundle exec exe/try try/${{ matrix.testgroup }}
+        run: COVERAGE=1 FORCE_COLOR=1 bundle exec exe/try try/core try/expectations try/formatters try/translators
 
   failure_is_an_option:
     timeout-minutes: 10

--- a/try/continue-on-error/type_expectations_try.rb
+++ b/try/continue-on-error/type_expectations_try.rb
@@ -14,7 +14,7 @@
 
 ## TEST: Supports ancestors
 "hello"
-#=:> Object
+#=:<> Object
 
 ## TEST: Multiple expectations with String class check first
 value = "test_string"

--- a/try/continue-on-error/type_expectations_try.rb
+++ b/try/continue-on-error/type_expectations_try.rb
@@ -12,9 +12,9 @@
 42
 #=:> Integer
 
-## TEST: Supports ancestors
+## TEST: Should fail with wrong type
 "hello"
-#=:<> Object
+#=:<> Integer
 
 ## TEST: Multiple expectations with String class check first
 value = "test_string"

--- a/try/expectations/type_expectations_try.rb
+++ b/try/expectations/type_expectations_try.rb
@@ -12,10 +12,6 @@
 42
 #=:> Integer
 
-## TEST: Should fail with wrong type
-"hello"
-#=:<> Integer
-
 ## TEST: Supports ancestors
 "hello"
 #=:> Object


### PR DESCRIPTION
### **PR Type**
Tests, Other


___

### **Description**
- Add Ruby 3.2 and 3.3 to CI matrix

- Remove unnecessary reverse logic test case

- Update test expectations for formatting failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Matrix"] --> B["Add Ruby 3.2/3.3"]
  C["Test Cases"] --> D["Remove reverse logic test"]
  C --> E["Update type expectations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Expand CI matrix with additional Ruby versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add Ruby 3.2 and 3.3 versions to CI matrix<br> <li> Run all test groups for each Ruby version</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/53/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>type_expectations_try.rb</strong><dd><code>Clean up type expectation test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/continue-on-error/type_expectations_try.rb

<ul><li>Remove test case for wrong type expectation<br> <li> Change Object type expectation to use negative assertion</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/53/files#diff-e4a8b44cf2961fd2c2b08b48bcf0d98e2eb48c86137653d6078794a3750ef97b">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

