### PR TITLE
Improve agent output DX with consistent section headers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "Github Actions" 
+  - package-ecosystem: "Github Actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-  - package-ecosystem: "Bundler" 
-    directory: "/" 
+  - package-ecosystem: "Bundler"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GIT
 PATH
   remote: .
   specs:
-    tryouts (3.5.2)
+    tryouts (3.6.0)
       concurrent-ruby (~> 1.0)
       irb
       minitest (~> 5.0)

--- a/lib/tryouts/cli/formatters/agent.rb
+++ b/lib/tryouts/cli/formatters/agent.rb
@@ -295,7 +295,9 @@ class Tryouts
           details = []
           details << "#{failed_count} failed" if failed_count > 0
           details << "#{error_count} errors" if error_count > 0
-          status_parts << "SUMMARY: #{issues_count}/#{@total_stats[:tests]} tests failed (#{details.join(', ')}, #{passed_count} passed#{time_str})"
+          summary = "#{passed_count} testcases passed, #{failed_count} failed"
+          summary += ", #{error_count} errors" if error_count > 0
+          status_parts << "SUMMARY: #{summary}#{time_str}"
         else
           # Agent doesn't need output in the positive case (i.e. for passing
           # tests). It just fills out the context window.

--- a/lib/tryouts/cli/formatters/agent.rb
+++ b/lib/tryouts/cli/formatters/agent.rb
@@ -284,10 +284,6 @@ class Tryouts
           " (#{@total_stats[:elapsed_time].round(2)}s)"
         end
 
-        # Add execution context header for agent clarity
-        output << render_execution_context
-        output << ""
-
         # Count failures manually from collected file data (same as other render methods)
         failed_count = @collected_files.sum { |f| f[:failures].size }
         error_count = @collected_files.sum { |f| f[:errors].size }
@@ -330,6 +326,10 @@ class Tryouts
           end
         end
 
+        # Add execution context at the end
+        output << ""
+        output << render_execution_context
+
         puts output.join("\n") if output.any?
       end
 
@@ -345,19 +345,20 @@ class Tryouts
 
         output = []
 
-        # Add execution context header for agent clarity
-        output << render_execution_context
-        output << ""
-
         if critical_files.empty?
           output << "No critical errors found"
+          # Add execution context at the end
+          output << ""
+          output << render_execution_context
           puts output.join("\n")
           return
         end
 
+        # Summary first
         output << "CRITICAL: #{critical_files.size} file#{'s' if critical_files.size != 1} with errors#{time_str}"
         output << ""
 
+        # Error details
         critical_files.each do |file_data|
           unless @budget.has_budget?
             output << "... (truncated due to token limit)"
@@ -379,6 +380,9 @@ class Tryouts
           output << ""
         end
 
+        # Add execution context at the end
+        output << render_execution_context
+
         puts output.join("\n")
       end
 
@@ -391,15 +395,19 @@ class Tryouts
           " (#{@total_stats[:elapsed_time].round(2)}s)"
         end
 
-        # Add execution context header for agent clarity
-        output << render_execution_context
-        output << ""
-
         # Count actual failures from collected data
         failed_count = @collected_files.sum { |f| f[:failures].size }
         error_count = @collected_files.sum { |f| f[:errors].size }
         issues_count = failed_count + error_count
         passed_count = [@total_stats[:tests] - issues_count, 0].max
+
+        # Summary first
+        summary = "Summary: \n"
+        summary += "#{passed_count} testcases passed, #{failed_count} failed"
+        summary += ", #{error_count} errors" if error_count > 0
+        summary += " in #{@total_stats[:files]} files#{time_str}"
+        output << summary
+        output << ""
 
         # Show files with issues only
         files_with_issues = @collected_files.select { |f| f[:failures].any? || f[:errors].any? }
@@ -422,13 +430,8 @@ class Tryouts
           output << ""
         end
 
-        # Final summary line
-        summary = "Summary: \n"
-        summary += "#{passed_count} testcases passed, #{failed_count} failed"
-        summary += ", #{error_count} errors" if error_count > 0
-        summary += " in #{@total_stats[:files]} files#{time_str}"
-
-        output << summary
+        # Add execution context at the end
+        output << render_execution_context
 
         puts output.join("\n")
       end

--- a/lib/tryouts/cli/formatters/agent.rb
+++ b/lib/tryouts/cli/formatters/agent.rb
@@ -295,7 +295,7 @@ class Tryouts
           details = []
           details << "#{failed_count} failed" if failed_count > 0
           details << "#{error_count} errors" if error_count > 0
-          status_parts << "FAIL: #{issues_count}/#{@total_stats[:tests]} tests (#{details.join(', ')}, #{passed_count} passed#{time_str})"
+          status_parts << "SUMMARY: #{issues_count}/#{@total_stats[:tests]} tests failed (#{details.join(', ')}, #{passed_count} passed#{time_str})"
         else
           # Agent doesn't need output in the positive case (i.e. for passing
           # tests). It just fills out the context window.
@@ -310,14 +310,14 @@ class Tryouts
 
         files_with_issues = @collected_files.select { |f| f[:failures].any? || f[:errors].any? }
         if files_with_issues.any?
-          output << "Files:"
+          output << "FILES:"
           files_with_issues.each do |file_data|
             issue_count = file_data[:failures].size + file_data[:errors].size
             output << "  #{file_data[:path]}: #{issue_count} issue#{'s' if issue_count != 1}"
           end
         elsif @collected_files.any?
           # Show files that were processed successfully
-          output << "Files:"
+          output << "FILES:"
           @collected_files.each do |file_data|
             # Use the passed count from file_result if available, otherwise calculate
             passed_tests = file_data[:passed] ||
@@ -355,7 +355,8 @@ class Tryouts
         end
 
         # Summary first
-        output << "CRITICAL: #{critical_files.size} file#{'s' if critical_files.size != 1} with errors#{time_str}"
+        output << "SUMMARY:"
+        output << "#{critical_files.size} file#{'s' if critical_files.size != 1} with critical errors#{time_str}"
         output << ""
 
         # Error details
@@ -402,8 +403,8 @@ class Tryouts
         passed_count = [@total_stats[:tests] - issues_count, 0].max
 
         # Summary first
-        summary = "Summary: \n"
-        summary += "#{passed_count} testcases passed, #{failed_count} failed"
+        output << "SUMMARY:"
+        summary = "#{passed_count} testcases passed, #{failed_count} failed"
         summary += ", #{error_count} errors" if error_count > 0
         summary += " in #{@total_stats[:files]} files#{time_str}"
         output << summary
@@ -556,7 +557,7 @@ class Tryouts
 
       def render_execution_context
         context_lines = []
-        context_lines << "EXECUTION_CONTEXT:"
+        context_lines << "CONTEXT:"
 
         # Command that was executed
         if @options[:original_command]

--- a/lib/tryouts/version.rb
+++ b/lib/tryouts/version.rb
@@ -1,5 +1,5 @@
 # lib/tryouts/version.rb
 
 class Tryouts
-  VERSION = '3.5.2'
+  VERSION = '3.6.0'
 end

--- a/try/regressions/setup_error_exit_code_try.rb
+++ b/try/regressions/setup_error_exit_code_try.rb
@@ -1,6 +1,6 @@
 ## Test that setup failures result in proper exit code 1
-## 
-## This regression test replicates the issue where setup failures 
+##
+## This regression test replicates the issue where setup failures
 ## would incorrectly exit with code 0 instead of 1 in agent mode.
 
 # Create a test file that has a setup failure similar to the real-world case
@@ -8,7 +8,7 @@ File.write('test_setup_failure_regression.try.rb', <<~TEST_FILE)
   # Setup that fails with a runtime error
   external_identifiers = require('object_identifiers')
   # This will raise a LoadError since object_identifiers doesn't exist
-  
+
   ## Test case that should not run due to setup failure
   puts 'This test should not execute'
   #=> nil


### PR DESCRIPTION
### **User description**
## Summary

This PR improves the developer experience when using Tryouts with Claude Code by addressing two key issues with agent output formatting.

The main problem was that execution context appeared first in the output, creating repetitive noise in Claude Code where users would see the same technical details repeatedly, with only the status changing between runs. This made it difficult to quickly identify actual test results.

## Changes Made

**Output Reordering**
- Summary now appears first (immediate status overview)
- Test results follow (detailed failures/errors when present)  
- Execution context moved to the end (technical details)

**Consistent Section Headers**
- Added explicit "SUMMARY:" header to all output modes
- Standardized to ALL CAPS: "FILES:" instead of "Files:"
- Shortened "EXECUTION_CONTEXT:" to "CONTEXT:" for brevity
- Updated status prefixes to use consistent "SUMMARY:" format

**Version Bump**
- Minor version bump to 3.6.0 reflecting the DX improvements
- Updated Gemfile.lock accordingly

## Impact

The changes apply to all three agent focus modes:
- `render_full_structured` (default agent mode)
- `render_summary_only` (--agent-focus summary)
- `render_critical_only` (--agent-focus critical)

**Before:**
```
EXECUTION_CONTEXT:
  command: bundle exec try --agent test.rb
  pid: 12345 | pwd: /path
  runtime: ruby 3.4.5
  ...

Summary:
2 testcases passed, 1 failed in 1 files
```

**After:**
```
SUMMARY:
2 testcases passed, 1 failed in 1 files

test.rb:
  L5: expected "world", got "hello"

CONTEXT:
  command: bundle exec try --agent test.rb
  runtime: ruby 3.4.5
  ...
```

This creates a much cleaner experience in Claude Code where users immediately see test results without scrolling through repetitive execution context.


___

### **PR Type**
Enhancement


___

### **Description**
- Reorder agent output: summary first, context last

- Standardize section headers to ALL CAPS format

- Improve Claude Code developer experience

- Minor version bump to 3.6.0


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Output"] --> B["Execution Context First"]
  B --> C["Summary Last"]
  D["New Output"] --> E["Summary First"]
  E --> F["Test Results"]
  F --> G["Context Last"]
  A --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.rb</strong><dd><code>Reorder output and standardize section headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/tryouts/cli/formatters/agent.rb

<ul><li>Reorder output sections: summary first, execution context last<br> <li> Standardize headers to ALL CAPS: "SUMMARY:", "FILES:", "CONTEXT:"<br> <li> Update status prefixes from "FAIL:" to "SUMMARY:"<br> <li> Apply changes across all three agent focus modes</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/54/files#diff-edccb3d882d46b559757b02db83cd508926478ccdc94d83571f28c8b15a4e002">+28/-24</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.rb</strong><dd><code>Version bump to 3.6.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/tryouts/version.rb

- Bump version from 3.5.2 to 3.6.0


</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/54/files#diff-4c463edf237ac9d2e0f735ab8a61c643e5748890a060c6bf2c0626c010f326c5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup_error_exit_code_try.rb</strong><dd><code>Code formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/regressions/setup_error_exit_code_try.rb

<ul><li>Remove trailing whitespace<br> <li> Fix inconsistent spacing and line endings</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/54/files#diff-e916ff51db918120d3ca50ce42f12f2f41793b7813e42b2789ddf7a807fd62f2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Remove trailing whitespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

- Remove trailing whitespace from configuration lines


</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/54/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

