### PR TITLE
Revert incorrect markdown table syntax change

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Each test file is made up of three sections:
   | `#=>`  | Traditional value equality | `#=> [1, 2, 3]`                     | result, _     |
   | `#==>` | Must be exactly true       | `#==> result.include?(2)`            | result, _     |
   | `#=/=>`| Must be exactly false      | `#=/=> _.empty?`                     | result, _     |
-  | `#=|>` | Must be true OR false     | `#=|> 0.positive?`                   | result, _     |
+  | `#=\|>` | Must be true OR false     | `#=\|> 0.positive?`                   | result, _     |
   | `#=!>` | Must raise an exception    | `#=!> error.is_a?(ZeroDivisionError)` | error         |
   | `#=:>` | Must match result type     | `#=:> String`                         | result, _     |
   | `#=~>` | Must match regex pattern   | `#=~> /^[^@]+@[^@]+\.[^@]+$/`         | result, _     |


### PR DESCRIPTION
### **User description**
The pipe character in #=|> needs to be escaped as #=\|> in markdown tables to prevent it being interpreted as a column delimiter.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Escape pipe character in markdown table syntax

- Prevent pipe from being interpreted as column delimiter

- Fix rendering of `#=|>` operator documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README.md markdown table"] -- "escape pipe character" --> B["#=\|> syntax corrected"]
  B -- "prevents misinterpretation" --> C["proper table rendering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Escape pipe in markdown table syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Escaped pipe character in <code>#=|></code> operator from <code>#=|></code> to <code>#=\|></code><br> <li> Applied escape in both the operator column and example code column<br> <li> Ensures markdown table parser treats pipe as literal character, not <br>delimiter</ul>


</details>


  </td>
  <td><a href="https://github.com/delano/tryouts/pull/63/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

